### PR TITLE
fix: handling failed events

### DIFF
--- a/async_consumer.go
+++ b/async_consumer.go
@@ -37,13 +37,7 @@ func (t *AsyncEventConsumer) Handle(ctx Context) (int, error) {
 	}
 
 	failedEvents := t.Consumer(ctx, events)
-
-	for i := range failedEvents {
-		e := failedEvents[i]
-		e.Attempts += 1
-	}
-
-	if err := failedEvents.Update(ctx, tx.Conn()); err != nil {
+	if err := failedEvents.Recreate(ctx, tx.Conn()); err != nil {
 		ctx.Debugf("error saving event attempt updates to event_queue: %v\n", err)
 	}
 


### PR DESCRIPTION
we have been deleting all the failed async events.
We update the attempt count of the failed events but the event fetcher query deletes it anyway.

Instead, now we recreate totally new events from the failed ones.